### PR TITLE
add libffi needed for python >= 3.7

### DIFF
--- a/lib/itamae/plugin/recipe/pyenv/install.rb
+++ b/lib/itamae/plugin/recipe/pyenv/install.rb
@@ -1,10 +1,12 @@
 case node.platform
 when "debian", "ubuntu"
   package "build-essential"
+  package "libffi-dev"
 when "redhat", "fedora", "amazon"
   package "gcc"
   package "zlib-devel"
   package "openssl-devel"
+  package "libffi-devel"
 end
 
 package "git"


### PR DESCRIPTION
From python >= 3.7, libffi will be needed for building.
So, add them as dependency.

https://github.com/pyenv/pyenv/issues/1183